### PR TITLE
geom_alt props

### DIFF
--- a/data/421/168/899/421168899.geojson
+++ b/data/421/168/899/421168899.geojson
@@ -627,6 +627,9 @@
     ],
     "wof:country":"KG",
     "wof:created":1459008785,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6e4e3cea6df1b50f77c8911879b3f7f2",
     "wof:hierarchy":[
         {
@@ -638,7 +641,7 @@
         }
     ],
     "wof:id":421168899,
-    "wof:lastmodified":1566727162,
+    "wof:lastmodified":1582345709,
     "wof:name":"Bishkek",
     "wof:parent_id":1091692295,
     "wof:placetype":"locality",

--- a/data/856/327/61/85632761.geojson
+++ b/data/856/327/61/85632761.geojson
@@ -1049,7 +1049,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "meso",
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1125,7 +1124,7 @@
         "kir",
         "rus"
     ],
-    "wof:lastmodified":1582345703,
+    "wof:lastmodified":1583224602,
     "wof:name":"Kyrgyzstan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/327/61/85632761.geojson
+++ b/data/856/327/61/85632761.geojson
@@ -1048,8 +1048,9 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "meso",
         "naturalearth",
-        "meso"
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
@@ -1103,6 +1104,11 @@
     },
     "wof:country":"KG",
     "wof:country_alpha3":"KGZ",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"4947deabca5fba7043b02646eaf2e156",
     "wof:hierarchy":[
         {
@@ -1119,7 +1125,7 @@
         "kir",
         "rus"
     ],
-    "wof:lastmodified":1566727104,
+    "wof:lastmodified":1582345703,
     "wof:name":"Kyrgyzstan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/729/75/85672975.geojson
+++ b/data/856/729/75/85672975.geojson
@@ -631,6 +631,9 @@
         421168899
     ],
     "wof:country":"KG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a598809257d37f51d822e679c8706b98",
     "wof:hierarchy":[
         {
@@ -648,7 +651,7 @@
         "kir",
         "rus"
     ],
-    "wof:lastmodified":1566727107,
+    "wof:lastmodified":1582345705,
     "wof:name":"Bishkek",
     "wof:parent_id":85632761,
     "wof:placetype":"region",

--- a/data/856/729/81/85672981.geojson
+++ b/data/856/729/81/85672981.geojson
@@ -327,6 +327,9 @@
         "wk:page":"Chuy Region"
     },
     "wof:country":"KG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c1568253d29bbdcf50a4ed798aff9a1f",
     "wof:hierarchy":[
         {
@@ -344,7 +347,7 @@
         "kir",
         "rus"
     ],
-    "wof:lastmodified":1566727107,
+    "wof:lastmodified":1582345705,
     "wof:name":"Chuy",
     "wof:parent_id":85632761,
     "wof:placetype":"region",

--- a/data/856/729/83/85672983.geojson
+++ b/data/856/729/83/85672983.geojson
@@ -341,6 +341,9 @@
         "wk:page":"Issyk-Kul Region"
     },
     "wof:country":"KG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"932b1a3d5d3e64ac67ae66b4be63acfa",
     "wof:hierarchy":[
         {
@@ -358,7 +361,7 @@
         "kir",
         "rus"
     ],
-    "wof:lastmodified":1566727107,
+    "wof:lastmodified":1582345706,
     "wof:name":"Ysyk-K\u00f6l",
     "wof:parent_id":85632761,
     "wof:placetype":"region",

--- a/data/856/729/87/85672987.geojson
+++ b/data/856/729/87/85672987.geojson
@@ -345,6 +345,9 @@
         "wk:page":"Naryn Region"
     },
     "wof:country":"KG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"589286b1a3912c1e01ec550fa5bc480e",
     "wof:hierarchy":[
         {
@@ -362,7 +365,7 @@
         "kir",
         "rus"
     ],
-    "wof:lastmodified":1566727106,
+    "wof:lastmodified":1582345705,
     "wof:name":"Naryn",
     "wof:parent_id":85632761,
     "wof:placetype":"region",

--- a/data/856/729/95/85672995.geojson
+++ b/data/856/729/95/85672995.geojson
@@ -334,6 +334,9 @@
         "wk:page":"Batken Region"
     },
     "wof:country":"KG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f2a2d934a68ef0fb6c2a5036ba9d32c6",
     "wof:hierarchy":[
         {
@@ -351,7 +354,7 @@
         "kir",
         "rus"
     ],
-    "wof:lastmodified":1566727106,
+    "wof:lastmodified":1582345704,
     "wof:name":"Batken",
     "wof:parent_id":85632761,
     "wof:placetype":"region",

--- a/data/856/729/97/85672997.geojson
+++ b/data/856/729/97/85672997.geojson
@@ -315,6 +315,9 @@
         "wk:page":"Jalal-Abad Region"
     },
     "wof:country":"KG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a5ecc18a58c91793b90340752db8c484",
     "wof:hierarchy":[
         {
@@ -332,7 +335,7 @@
         "kir",
         "rus"
     ],
-    "wof:lastmodified":1566727107,
+    "wof:lastmodified":1582345705,
     "wof:name":"Jalal-Abad",
     "wof:parent_id":85632761,
     "wof:placetype":"region",

--- a/data/856/730/03/85673003.geojson
+++ b/data/856/730/03/85673003.geojson
@@ -339,6 +339,9 @@
         "wk:page":"Talas Region"
     },
     "wof:country":"KG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a524e1c4130f4c662a0eba6f89a3b362",
     "wof:hierarchy":[
         {
@@ -356,7 +359,7 @@
         "kir",
         "rus"
     ],
-    "wof:lastmodified":1566727103,
+    "wof:lastmodified":1582345702,
     "wof:name":"Talas",
     "wof:parent_id":85632761,
     "wof:placetype":"region",

--- a/data/856/730/05/85673005.geojson
+++ b/data/856/730/05/85673005.geojson
@@ -356,6 +356,9 @@
         "wk:page":"Osh Region"
     },
     "wof:country":"KG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"df1e8b09107ba72c10aa27ec7be3e2a6",
     "wof:hierarchy":[
         {
@@ -373,7 +376,7 @@
         "kir",
         "rus"
     ],
-    "wof:lastmodified":1566727104,
+    "wof:lastmodified":1582345702,
     "wof:name":"Osh",
     "wof:parent_id":85632761,
     "wof:placetype":"region",

--- a/data/859/031/51/85903151.geojson
+++ b/data/859/031/51/85903151.geojson
@@ -87,6 +87,9 @@
         "wd:id":"Q6452904"
     },
     "wof:country":"KG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b159c0d000c0f0d7bb1a89a3157a1d4a",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566727103,
+    "wof:lastmodified":1582345701,
     "wof:name":"Kyzyl-Asker",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/53/85903153.geojson
+++ b/data/859/031/53/85903153.geojson
@@ -100,6 +100,9 @@
         "wk:page":"Tokol'dosh"
     },
     "wof:country":"KG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"51d19e32283d3fa410a9798bd0a8716d",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566727103,
+    "wof:lastmodified":1582345701,
     "wof:name":"Tokol'dosh",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.