### PR TITLE
Name updates

### DIFF
--- a/data/856/327/61/85632761.geojson
+++ b/data/856/327/61/85632761.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":21.377242,
-    "geom:area_square_m":198054213246.825623,
+    "geom:area_square_m":198054211977.613586,
     "geom:bbox":"69.250998,39.180254,80.226559,43.265357",
     "geom:latitude":41.464774,
     "geom:longitude":74.529537,
@@ -69,6 +69,9 @@
     ],
     "name:arg_x_variant":[
         "Kirguisist\u00e1n"
+    ],
+    "name:ary_x_preferred":[
+        "\u0643\u064a\u0631\u063a\u064a\u0633\u062a\u0627\u0646"
     ],
     "name:arz_x_preferred":[
         "\u0643\u064a\u0631\u062c\u064a\u0632\u0633\u062a\u0627\u0646"
@@ -198,6 +201,12 @@
     "name:dan_x_preferred":[
         "Kirgisistan"
     ],
+    "name:deu_at_x_preferred":[
+        "Kirgisistan"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Kirgisistan"
+    ],
     "name:deu_x_preferred":[
         "Kirgisistan"
     ],
@@ -222,6 +231,12 @@
     ],
     "name:ell_x_variant":[
         "\u039a\u03b9\u03c1\u03b3\u03b9\u03c3\u03c4\u03ac\u03bd"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Kyrgyzstan"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Kyrgyzstan"
     ],
     "name:eng_x_preferred":[
         "Kyrgyzstan"
@@ -291,6 +306,9 @@
     ],
     "name:gag_x_preferred":[
         "K\u0131rg\u0131zstan"
+    ],
+    "name:gcr_x_preferred":[
+        "Kirgizistan"
     ],
     "name:gla_x_preferred":[
         "C\u00ecorgastan"
@@ -601,6 +619,9 @@
     "name:mya_x_variant":[
         "\u1001\u101a\u103a\u1000\u1005\u103a\u1005\u1010\u1014\u103a"
     ],
+    "name:myv_x_preferred":[
+        "\u041a\u0438\u0440\u0433\u0438\u0437\u0438\u044f \u041c\u0430\u0441\u0442\u043e\u0440"
+    ],
     "name:mzn_x_preferred":[
         "\u0642\u0631\u0642\u06cc\u0632\u0633\u062a\u0648\u0646"
     ],
@@ -697,6 +718,9 @@
     "name:pol_x_preferred":[
         "Kirgistan"
     ],
+    "name:por_br_x_preferred":[
+        "Quirguist\u00e3o"
+    ],
     "name:por_x_colloquial":[
         "Quirguizistao"
     ],
@@ -778,6 +802,9 @@
     "name:sme_x_preferred":[
         "Kirgisistan"
     ],
+    "name:smo_x_preferred":[
+        "Kyrgyzstan"
+    ],
     "name:sna_x_preferred":[
         "Kyrgyzstan"
     ],
@@ -809,6 +836,12 @@
     "name:srd_x_preferred":[
         "Kirgizist\u00e0n"
     ],
+    "name:srp_ec_x_preferred":[
+        "\u041a\u0438\u0440\u0433\u0438\u0441\u0442\u0430\u043d"
+    ],
+    "name:srp_el_x_preferred":[
+        "Kirgistan"
+    ],
     "name:srp_x_preferred":[
         "\u041a\u0438\u0440\u0433\u0438\u0441\u0442\u0430\u043d"
     ],
@@ -833,6 +866,9 @@
     ],
     "name:szl_x_preferred":[
         "Kirgistan"
+    ],
+    "name:szy_x_preferred":[
+        "Kurgyzstan"
     ],
     "name:tam_x_preferred":[
         "\u0b95\u0bbf\u0bb0\u0bcd\u0b95\u0bbf\u0b9a\u0bc1\u0ba4\u0bcd\u0ba4\u0bbe\u0ba9\u0bcd"
@@ -958,8 +994,26 @@
     "name:zha_x_preferred":[
         "Kyrgyzstan"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u5409\u5c14\u5409\u65af\u65af\u5766"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5409\u723e\u5409\u65af"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Kyrgyzstan"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u5409\u723e\u5409\u65af\u65af\u5766"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u5409\u5c14\u5409\u65af\u65af\u5766"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u5409\u5c14\u5409\u65af\u65af\u5766"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u5409\u723e\u5409\u65af"
     ],
     "name:zho_x_preferred":[
         "\u5409\u5c14\u5409\u65af\u65af\u5766"
@@ -1125,7 +1179,7 @@
         "kir",
         "rus"
     ],
-    "wof:lastmodified":1583797375,
+    "wof:lastmodified":1587428009,
     "wof:name":"Kyrgyzstan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.