### PR TITLE
Update megacity records

### DIFF
--- a/data/421/168/899/421168899.geojson
+++ b/data/421/168/899/421168899.geojson
@@ -621,6 +621,7 @@
     "wof:concordances":{
         "gn:id":1528675,
         "gp:id":1969888,
+        "ne:id":1159150813,
         "qs_pg:id":274012,
         "wd:id":"Q9361"
     },
@@ -643,7 +644,8 @@
         }
     ],
     "wof:id":421168899,
-    "wof:lastmodified":1607390892,
+    "wof:lastmodified":1608688177,
+    "wof:megacity":1,
     "wof:name":"Bishkek",
     "wof:parent_id":1091692295,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary