### PR TITLE
kg concordances, placetype local, and more

### DIFF
--- a/data/109/169/014/3/1091690143.geojson
+++ b/data/109/169/014/3/1091690143.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.558271,
-    "geom:area_square_m":5097079299.781749,
+    "geom:area_square_m":5097079584.780793,
     "geom:bbox":"72.084881,42.049063,73.658246,42.769576",
     "geom:latitude":42.406804,
     "geom:longitude":72.728158,
@@ -124,9 +124,10 @@
     "wof:concordances":{
         "hasc:id":"KG.TL.TC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879325,
-    "wof:geomhash":"9d5d7393519f621d68f5ec5bc6898c30",
+    "wof:geomhash":"9577926b0a6bc73a7cf668afcb55ea9f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1091690143,
-    "wof:lastmodified":1636500642,
+    "wof:lastmodified":1695886762,
     "wof:name":"Talas",
     "wof:parent_id":85673003,
     "wof:placetype":"county",

--- a/data/109/169/016/1/1091690161.geojson
+++ b/data/109/169/016/1/1091690161.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.255603,
-    "geom:area_square_m":2335896079.08855,
+    "geom:area_square_m":2335895881.320011,
     "geom:bbox":"71.606527,42.055458,72.346361,42.666301",
     "geom:latitude":42.347404,
     "geom:longitude":71.947748,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"KG.TL.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879326,
-    "wof:geomhash":"549082fd12cfb36d973b10b2f819ff4a",
+    "wof:geomhash":"560f5683b0f5fd071a4da9a407846f30",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1091690161,
-    "wof:lastmodified":1642551801,
+    "wof:lastmodified":1695886525,
     "wof:name":"Bakai-Ata",
     "wof:parent_id":85673003,
     "wof:placetype":"county",

--- a/data/109/169/031/3/1091690313.geojson
+++ b/data/109/169/031/3/1091690313.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.114945,
-    "geom:area_square_m":1044195775.785418,
+    "geom:area_square_m":1044195717.120477,
     "geom:bbox":"71.331628,42.5474,72.151502,42.840584",
     "geom:latitude":42.721109,
     "geom:longitude":71.796964,
@@ -138,9 +138,10 @@
         "hasc:id":"KG.TL.MA",
         "wd:id":"Q2639118"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879328,
-    "wof:geomhash":"1551478a02c9cfeb983c9a9b2b9ffb0d",
+    "wof:geomhash":"14875b3105209b998bc59d83d9be6098",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1091690313,
-    "wof:lastmodified":1690938086,
+    "wof:lastmodified":1695886762,
     "wof:name":"Manas",
     "wof:parent_id":85673003,
     "wof:placetype":"county",

--- a/data/109/169/035/7/1091690357.geojson
+++ b/data/109/169/035/7/1091690357.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.323556,
-    "geom:area_square_m":2952069446.864303,
+    "geom:area_square_m":2952070010.228096,
     "geom:bbox":"70.864634,42.18138,71.732944,42.775624",
     "geom:latitude":42.450106,
     "geom:longitude":71.347851,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KG.TL.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879334,
-    "wof:geomhash":"b9fb96617a84cede1981f44c0570e325",
+    "wof:geomhash":"9bdebb6a1a9d210fbe1055d21d6eb4e0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1091690357,
-    "wof:lastmodified":1642551775,
+    "wof:lastmodified":1695886517,
     "wof:name":"Kara-Buura",
     "wof:parent_id":85673003,
     "wof:placetype":"county",

--- a/data/109/169/038/5/1091690385.geojson
+++ b/data/109/169/038/5/1091690385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.489508,
-    "geom:area_square_m":4646182274.776377,
+    "geom:area_square_m":4646182128.600961,
     "geom:bbox":"69.26385,39.521151,70.357624,40.234034",
     "geom:latitude":39.86081,
     "geom:longitude":69.789239,
@@ -62,9 +62,10 @@
     "wof:concordances":{
         "hasc:id":"KG.BA.LA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879336,
-    "wof:geomhash":"09a98bafdd0cafefbf33cd96114a9384",
+    "wof:geomhash":"f715189b16d47778e0feee0b2b31f8a5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1091690385,
-    "wof:lastmodified":1627522280,
+    "wof:lastmodified":1695886748,
     "wof:name":"Leilek",
     "wof:parent_id":85672995,
     "wof:placetype":"county",

--- a/data/109/169/042/7/1091690427.geojson
+++ b/data/109/169/042/7/1091690427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.645084,
-    "geom:area_square_m":6129817342.052608,
+    "geom:area_square_m":6129817754.03581,
     "geom:bbox":"70.087089,39.388948,71.555567,40.292402",
     "geom:latitude":39.78242,
     "geom:longitude":70.787116,
@@ -188,9 +188,10 @@
     "wof:concordances":{
         "hasc:id":"KG.BA.BT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879337,
-    "wof:geomhash":"47cfb0fcedb8cf1ffb1a46dbe5c0abb4",
+    "wof:geomhash":"dc5429586f7a953dc4b68439efcf69bb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -200,7 +201,7 @@
         }
     ],
     "wof:id":1091690427,
-    "wof:lastmodified":1636500643,
+    "wof:lastmodified":1695886762,
     "wof:name":"Batken",
     "wof:parent_id":85672995,
     "wof:placetype":"county",

--- a/data/109/169/047/9/1091690479.geojson
+++ b/data/109/169/047/9/1091690479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.647301,
-    "geom:area_square_m":6132597253.91181,
+    "geom:area_square_m":6132596964.658777,
     "geom:bbox":"71.032404,39.648247,72.544867,40.347447",
     "geom:latitude":39.986597,
     "geom:longitude":71.763595,
@@ -62,9 +62,10 @@
     "wof:concordances":{
         "hasc:id":"KG.BA.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879339,
-    "wof:geomhash":"3a49f1be96e39c4ff9c7f9fe6ed9b6a9",
+    "wof:geomhash":"818392cb2e6418c1f6090b9dc6b92cf5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1091690479,
-    "wof:lastmodified":1627522280,
+    "wof:lastmodified":1695886748,
     "wof:name":"Kadamjai",
     "wof:parent_id":85672995,
     "wof:placetype":"county",

--- a/data/109/169/051/9/1091690519.geojson
+++ b/data/109/169/051/9/1091690519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.508098,
-    "geom:area_square_m":4845578536.630014,
+    "geom:area_square_m":4845578310.365205,
     "geom:bbox":"71.498706,39.180427,72.927226,39.833258",
     "geom:latitude":39.533243,
     "geom:longitude":72.255551,
@@ -61,9 +61,10 @@
     "wof:concordances":{
         "hasc:id":"KG.OS.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879340,
-    "wof:geomhash":"c56f475841518538bb97ff75e2ed522f",
+    "wof:geomhash":"44cab9148c2c1ead7074eea126a9f7ab",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -73,7 +74,7 @@
         }
     ],
     "wof:id":1091690519,
-    "wof:lastmodified":1627522279,
+    "wof:lastmodified":1695886747,
     "wof:name":"Chon-Alai",
     "wof:parent_id":85673005,
     "wof:placetype":"county",

--- a/data/109/169/056/1/1091690561.geojson
+++ b/data/109/169/056/1/1091690561.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.795084,
-    "geom:area_square_m":7547231199.305124,
+    "geom:area_square_m":7547231355.673344,
     "geom:bbox":"72.800722,39.344671,74.038816,40.505591",
     "geom:latitude":39.854179,
     "geom:longitude":73.45946,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"KG.OH.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879342,
-    "wof:geomhash":"588522340d5bbf2c88b85362df2ec48b",
+    "wof:geomhash":"e30baf9581d6b791527021ba6f9c23a4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1091690561,
-    "wof:lastmodified":1627522278,
+    "wof:lastmodified":1695886746,
     "wof:name":"Alai",
     "wof:parent_id":85673005,
     "wof:placetype":"county",

--- a/data/109/169/060/3/1091690603.geojson
+++ b/data/109/169/060/3/1091690603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066362,
-    "geom:area_square_m":624388900.662281,
+    "geom:area_square_m":624388526.444932,
     "geom:bbox":"72.057928,40.339981,72.732682,40.618375",
     "geom:latitude":40.455208,
     "geom:longitude":72.427948,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KG.OH.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879343,
-    "wof:geomhash":"afb09093894b3684ded2c9659a6baaa5",
+    "wof:geomhash":"a733d2b3984a10a0190c396a2251995b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1091690603,
-    "wof:lastmodified":1627522279,
+    "wof:lastmodified":1695886747,
     "wof:name":"Aravan",
     "wof:parent_id":85673005,
     "wof:placetype":"county",

--- a/data/109/169/064/1/1091690641.geojson
+++ b/data/109/169/064/1/1091690641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.427544,
-    "geom:area_square_m":4042513631.659386,
+    "geom:area_square_m":4042513872.647623,
     "geom:bbox":"71.962757,39.779313,73.161268,40.429653",
     "geom:latitude":40.122778,
     "geom:longitude":72.613026,
@@ -113,9 +113,10 @@
     "wof:concordances":{
         "hasc:id":"KG.OH.NT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879345,
-    "wof:geomhash":"0b4b339ae93ff18feb235d160897c8ab",
+    "wof:geomhash":"11513f684af1f8fb28ef1d1ea221f755",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1091690641,
-    "wof:lastmodified":1627522281,
+    "wof:lastmodified":1695886749,
     "wof:name":"Nookat",
     "wof:parent_id":85673005,
     "wof:placetype":"county",

--- a/data/109/169/066/5/1091690665.geojson
+++ b/data/109/169/066/5/1091690665.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.609323,
-    "geom:area_square_m":5733078023.858187,
+    "geom:area_square_m":5733077332.47127,
     "geom:bbox":"73.358797,40.079746,74.911163,40.793171",
     "geom:latitude":40.454343,
     "geom:longitude":74.112899,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"KG.OH.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879346,
-    "wof:geomhash":"35a7329269749fa967813dcc1d5f73ab",
+    "wof:geomhash":"91906f1a5b8ee84d0530de5ec9aff097",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091690665,
-    "wof:lastmodified":1627522280,
+    "wof:lastmodified":1695886748,
     "wof:name":"Kara-Kulja",
     "wof:parent_id":85673005,
     "wof:placetype":"county",

--- a/data/109/169/070/5/1091690705.geojson
+++ b/data/109/169/070/5/1091690705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.3644,
-    "geom:area_square_m":3409358000.849236,
+    "geom:area_square_m":3409358000.848953,
     "geom:bbox":"73.093823597,40.470123759,74.260311304,41.146402055",
     "geom:latitude":40.830411,
     "geom:longitude":73.588053,
@@ -174,9 +174,10 @@
     "wof:concordances":{
         "hasc:id":"KG.OH.UZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879348,
-    "wof:geomhash":"8dfcf47454f7525da74fa8c86dae8e7d",
+    "wof:geomhash":"936bac0c5a87a66018662554970104c6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -186,7 +187,7 @@
         }
     ],
     "wof:id":1091690705,
-    "wof:lastmodified":1566727154,
+    "wof:lastmodified":1695886185,
     "wof:name":"Uzgen",
     "wof:parent_id":85673005,
     "wof:placetype":"county",

--- a/data/109/169/075/1/1091690751.geojson
+++ b/data/109/169/075/1/1091690751.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.30725,
-    "geom:area_square_m":2895400472.870373,
+    "geom:area_square_m":2895400630.071497,
     "geom:bbox":"72.663871,39.812862,73.38476,40.770937",
     "geom:latitude":40.349164,
     "geom:longitude":73.049496,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KG.OH.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879349,
-    "wof:geomhash":"6e3c65dde136e6fe86b9b912d2b58c1f",
+    "wof:geomhash":"be48558a37c50e1f9adc751a90e46246",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1091690751,
-    "wof:lastmodified":1627522280,
+    "wof:lastmodified":1695886748,
     "wof:name":"Kara-suu",
     "wof:parent_id":85673005,
     "wof:placetype":"county",

--- a/data/109/169/077/9/1091690779.geojson
+++ b/data/109/169/077/9/1091690779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.662888,
-    "geom:area_square_m":6108895356.830389,
+    "geom:area_square_m":6108895100.765144,
     "geom:bbox":"70.169149,41.209369,71.980396,42.2158",
     "geom:latitude":41.816139,
     "geom:longitude":71.095965,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KG.DA.CK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879351,
-    "wof:geomhash":"6e5eec6c3216027829a7f034969cb511",
+    "wof:geomhash":"aecbb3be0ed1bb864f4630b77c4b1130",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1091690779,
-    "wof:lastmodified":1627522281,
+    "wof:lastmodified":1695886749,
     "wof:name":"Chatkal",
     "wof:parent_id":85672997,
     "wof:placetype":"county",

--- a/data/109/169/081/5/1091690815.geojson
+++ b/data/109/169/081/5/1091690815.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.936884,
-    "geom:area_square_m":8633603446.819523,
+    "geom:area_square_m":8633603215.296959,
     "geom:bbox":"71.912299,41.44106,74.086382,42.221187",
     "geom:latitude":41.818652,
     "geom:longitude":72.998273,
@@ -158,9 +158,10 @@
     "wof:concordances":{
         "hasc:id":"KG.DA.TG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879352,
-    "wof:geomhash":"dada53f38173990b597809158b78870c",
+    "wof:geomhash":"52f0b8e5c226ff49b11e575f63f59e8d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -170,7 +171,7 @@
         }
     ],
     "wof:id":1091690815,
-    "wof:lastmodified":1636500644,
+    "wof:lastmodified":1695886763,
     "wof:name":"Toktogul",
     "wof:parent_id":85672997,
     "wof:placetype":"county",

--- a/data/109/169/086/1/1091690861.geojson
+++ b/data/109/169/086/1/1091690861.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.423871,
-    "geom:area_square_m":3932555192.194903,
+    "geom:area_square_m":3932555907.690903,
     "geom:bbox":"73.372794,40.976259,74.74013,41.641882",
     "geom:latitude":41.38273,
     "geom:longitude":74.040826,
@@ -124,9 +124,10 @@
         "hasc:id":"KG.DA.TT",
         "wd:id":"Q754798"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879354,
-    "wof:geomhash":"4da3b11c5b34651496d06b56c1b90133",
+    "wof:geomhash":"831472d39bdecdf7199dc988f5093a8f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1091690861,
-    "wof:lastmodified":1690938087,
+    "wof:lastmodified":1695886749,
     "wof:name":"Toguz-Toro",
     "wof:parent_id":85672997,
     "wof:placetype":"county",

--- a/data/109/169/090/3/1091690903.geojson
+++ b/data/109/169/090/3/1091690903.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.325557,
-    "geom:area_square_m":3018865478.863743,
+    "geom:area_square_m":3018865636.518624,
     "geom:bbox":"70.715962,41.112583,71.675747,41.740431",
     "geom:latitude":41.416199,
     "geom:longitude":71.202616,
@@ -95,9 +95,10 @@
     "wof:concordances":{
         "hasc:id":"KG.DA.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879355,
-    "wof:geomhash":"cd73f90dda281f6b6938410a0203913e",
+    "wof:geomhash":"ab9b320b2ea15c980ecd16cdbc40485b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091690903,
-    "wof:lastmodified":1627522278,
+    "wof:lastmodified":1695886746,
     "wof:name":"Ala-Buka",
     "wof:parent_id":85672997,
     "wof:placetype":"county",

--- a/data/109/169/094/3/1091690943.geojson
+++ b/data/109/169/094/3/1091690943.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.497384,
-    "geom:area_square_m":4598021899.545564,
+    "geom:area_square_m":4598021685.107941,
     "geom:bbox":"71.41356,41.119887,72.512773,42.011692",
     "geom:latitude":41.615411,
     "geom:longitude":71.978051,
@@ -62,9 +62,10 @@
     "wof:concordances":{
         "hasc:id":"KG.DA.AK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879357,
-    "wof:geomhash":"98b8a01e9cd5587fc1b0bf86a2cfdbc9",
+    "wof:geomhash":"838b17e755a8b01104c11986919c09c1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1091690943,
-    "wof:lastmodified":1627522278,
+    "wof:lastmodified":1695886746,
     "wof:name":"Aksy",
     "wof:parent_id":85672997,
     "wof:placetype":"county",

--- a/data/109/169/098/1/1091690981.geojson
+++ b/data/109/169/098/1/1091690981.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.249972,
-    "geom:area_square_m":2323990482.21521,
+    "geom:area_square_m":2323990703.383064,
     "geom:bbox":"72.151426,40.953451,72.940408,41.51074",
     "geom:latitude":41.247277,
     "geom:longitude":72.497852,
@@ -123,9 +123,10 @@
         "hasc:id":"KG.DA.NN",
         "wd:id":"Q2573293"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879358,
-    "wof:geomhash":"aa90effb7751a1f723ab8cd0471f5edd",
+    "wof:geomhash":"d015286ca27852182922c0fbd5a66f13",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1091690981,
-    "wof:lastmodified":1627522281,
+    "wof:lastmodified":1695886749,
     "wof:name":"Nooken",
     "wof:parent_id":85672997,
     "wof:placetype":"county",

--- a/data/109/169/103/1/1091691031.geojson
+++ b/data/109/169/103/1/1091691031.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.214768,
-    "geom:area_square_m":1995548128.534113,
+    "geom:area_square_m":1995548128.533602,
     "geom:bbox":"72.558135165,40.888127952,73.487062013,41.581704491",
     "geom:latitude":41.284827,
     "geom:longitude":72.988576,
@@ -113,9 +113,10 @@
     "wof:concordances":{
         "hasc:id":"KG.DA.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879360,
-    "wof:geomhash":"386d58fafaa820c604fd9a11638eeca6",
+    "wof:geomhash":"42f159fa5ec28b07c304531942a2f1bf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1091691031,
-    "wof:lastmodified":1566727153,
+    "wof:lastmodified":1695886184,
     "wof:name":"Bazar-Korgon",
     "wof:parent_id":85672997,
     "wof:placetype":"county",

--- a/data/109/169/105/3/1091691053.geojson
+++ b/data/109/169/105/3/1091691053.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.297237,
-    "geom:area_square_m":2769702131.239601,
+    "geom:area_square_m":2769702131.239776,
     "geom:bbox":"72.574621397,40.804199765,73.819834867,41.37487948",
     "geom:latitude":41.09845,
     "geom:longitude":73.256723,
@@ -100,9 +100,10 @@
     "wof:concordances":{
         "hasc:id":"KG.DA.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879361,
-    "wof:geomhash":"82a3e083adf0decd0e4e45b4a2f5f959",
+    "wof:geomhash":"5c269d8f76a91f5c67c01667a50331a3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1091691053,
-    "wof:lastmodified":1566727154,
+    "wof:lastmodified":1695886185,
     "wof:name":"Suzak",
     "wof:parent_id":85672997,
     "wof:placetype":"county",

--- a/data/109/169/110/1/1091691101.geojson
+++ b/data/109/169/110/1/1091691101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.586067,
-    "geom:area_square_m":5394624863.937879,
+    "geom:area_square_m":5394623428.71583,
     "geom:bbox":"73.712814,41.541818,75.181975,42.245184",
     "geom:latitude":41.891182,
     "geom:longitude":74.538148,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KG.NA.JU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879363,
-    "wof:geomhash":"f79c7d5fbe8c9b2d8a1ebfc9116b06ea",
+    "wof:geomhash":"4967a889aacdacab38f5a42830f2bfb6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1091691101,
-    "wof:lastmodified":1627522279,
+    "wof:lastmodified":1695886747,
     "wof:name":"Jumgal",
     "wof:parent_id":85672987,
     "wof:placetype":"county",

--- a/data/109/169/114/3/1091691143.geojson
+++ b/data/109/169/114/3/1091691143.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.697462,
-    "geom:area_square_m":6397259311.543207,
+    "geom:area_square_m":6397260015.818098,
     "geom:bbox":"74.68964,41.736356,76.65587,42.453003",
     "geom:latitude":42.116853,
     "geom:longitude":75.60062,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KG.NA.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879364,
-    "wof:geomhash":"20beb5cc3e3ddf135928e174d492e2f6",
+    "wof:geomhash":"c39a52f3c5908e9438bf39e1d0e6b80c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1091691143,
-    "wof:lastmodified":1627522280,
+    "wof:lastmodified":1695886748,
     "wof:name":"Kochokor",
     "wof:parent_id":85672987,
     "wof:placetype":"county",

--- a/data/109/169/117/5/1091691175.geojson
+++ b/data/109/169/117/5/1091691175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.691169,
-    "geom:area_square_m":6425492446.885736,
+    "geom:area_square_m":6425491712.260344,
     "geom:bbox":"74.013292,40.877398,75.34747,41.785029",
     "geom:latitude":41.250117,
     "geom:longitude":74.780149,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KG.NA.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879366,
-    "wof:geomhash":"c1294f141b40962dafb8bd7e8180ef31",
+    "wof:geomhash":"6d6b3b00751ba8002e7844280fb1eb1b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1091691175,
-    "wof:lastmodified":1627522278,
+    "wof:lastmodified":1695886746,
     "wof:name":"Ak-Tala",
     "wof:parent_id":85672987,
     "wof:placetype":"county",

--- a/data/109/169/122/1/1091691221.geojson
+++ b/data/109/169/122/1/1091691221.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.845184,
-    "geom:area_square_m":7820831374.278591,
+    "geom:area_square_m":7820831429.605481,
     "geom:bbox":"75.185759,41.145658,77.369822,41.876411",
     "geom:latitude":41.552761,
     "geom:longitude":76.090975,
@@ -193,9 +193,10 @@
     "wof:concordances":{
         "hasc:id":"KG.NA.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879367,
-    "wof:geomhash":"130079fec4e13c83a30ba02a00a8f592",
+    "wof:geomhash":"15fa8b3b017850daef8e35703e4117f4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -205,7 +206,7 @@
         }
     ],
     "wof:id":1091691221,
-    "wof:lastmodified":1636500644,
+    "wof:lastmodified":1695886763,
     "wof:name":"Naryn",
     "wof:parent_id":85672987,
     "wof:placetype":"county",

--- a/data/109/169/127/3/1091691273.geojson
+++ b/data/109/169/127/3/1091691273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.397669,
-    "geom:area_square_m":3612693712.949881,
+    "geom:area_square_m":3612693478.583361,
     "geom:bbox":"76.12536,42.464807,77.969046,42.941789",
     "geom:latitude":42.718324,
     "geom:longitude":77.039471,
@@ -248,9 +248,10 @@
     "wof:concordances":{
         "hasc:id":"KG.YK.YK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879369,
-    "wof:geomhash":"cbe72be70ebd60be62d7c80d13cf881f",
+    "wof:geomhash":"4d49da8d66f0bb82733d90e6dcc44624",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -260,7 +261,7 @@
         }
     ],
     "wof:id":1091691273,
-    "wof:lastmodified":1636500643,
+    "wof:lastmodified":1695886763,
     "wof:name":"Issyk-Kul",
     "wof:parent_id":85672983,
     "wof:placetype":"county",

--- a/data/109/169/131/9/1091691319.geojson
+++ b/data/109/169/131/9/1091691319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.778582,
-    "geom:area_square_m":7150960270.197833,
+    "geom:area_square_m":7150960481.026839,
     "geom:bbox":"75.641311,41.553815,77.527913,42.617958",
     "geom:latitude":42.030779,
     "geom:longitude":76.709237,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"KG.YK.TN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879370,
-    "wof:geomhash":"86dbd9fb07fa84847925373ea1368e55",
+    "wof:geomhash":"da006a24bcf0560e7ef8d8b5047e4348",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1091691319,
-    "wof:lastmodified":1627522281,
+    "wof:lastmodified":1695886749,
     "wof:name":"Ton",
     "wof:parent_id":85672983,
     "wof:placetype":"county",

--- a/data/109/169/135/5/1091691355.geojson
+++ b/data/109/169/135/5/1091691355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.470195,
-    "geom:area_square_m":13548122653.437119,
+    "geom:area_square_m":13548122815.287226,
     "geom:bbox":"77.268246,41.181538,79.487265,42.581236",
     "geom:latitude":41.818341,
     "geom:longitude":78.124513,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"KG.YK.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879372,
-    "wof:geomhash":"c38dcaec00c4c4b207b0bbdd3ae5706f",
+    "wof:geomhash":"e6d29822fd09ded311ac9d98d0f9a619",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1091691355,
-    "wof:lastmodified":1627522279,
+    "wof:lastmodified":1695886747,
     "wof:name":"Jeti-Oguz",
     "wof:parent_id":85672983,
     "wof:placetype":"county",

--- a/data/109/169/140/7/1091691407.geojson
+++ b/data/109/169/140/7/1091691407.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.23159,
-    "geom:area_square_m":2103753927.785518,
+    "geom:area_square_m":2103753527.900813,
     "geom:bbox":"77.948749,42.473074,79.45124,42.902149",
     "geom:latitude":42.72326,
     "geom:longitude":78.593858,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"KG.YK.TU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879374,
-    "wof:geomhash":"e9770c027bb94b1f134122ff5021eca5",
+    "wof:geomhash":"d46b25ae955527a761c71e71c720e9a6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1091691407,
-    "wof:lastmodified":1627522281,
+    "wof:lastmodified":1695886749,
     "wof:name":"Tup",
     "wof:parent_id":85672983,
     "wof:placetype":"county",

--- a/data/109/169/145/5/1091691455.geojson
+++ b/data/109/169/145/5/1091691455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.041534,
-    "geom:area_square_m":9530504156.963577,
+    "geom:area_square_m":9530503957.245367,
     "geom:bbox":"78.238,41.824944,80.226452,42.745142",
     "geom:latitude":42.266799,
     "geom:longitude":79.193907,
@@ -125,9 +125,10 @@
         "hasc:id":"KG.YK.AS",
         "wd:id":"Q755002"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879375,
-    "wof:geomhash":"bd19b9e246d77ae1d1b105bbaa4fcd28",
+    "wof:geomhash":"d872cede1e144269b3a08ae89dc81e5e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1091691455,
-    "wof:lastmodified":1690938086,
+    "wof:lastmodified":1695886186,
     "wof:name":"Ak-Suu",
     "wof:parent_id":85672983,
     "wof:placetype":"county",

--- a/data/109/169/151/1/1091691511.geojson
+++ b/data/109/169/151/1/1091691511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.538119,
-    "geom:area_square_m":4914521316.329101,
+    "geom:area_square_m":4914521316.329186,
     "geom:bbox":"73.050635772,41.947252934,74.874310414,43.099178969",
     "geom:latitude":42.388111,
     "geom:longitude":73.811293,
@@ -101,9 +101,10 @@
     "wof:concordances":{
         "hasc:id":"KG.CU.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879378,
-    "wof:geomhash":"9342bcde67ff0b4df42324d38d56e49a",
+    "wof:geomhash":"b8c24d94537804b911fd09b65f4e5c41",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1091691511,
-    "wof:lastmodified":1566727154,
+    "wof:lastmodified":1695886185,
     "wof:name":"Panfilov",
     "wof:parent_id":85672981,
     "wof:placetype":"county",

--- a/data/109/169/155/5/1091691555.geojson
+++ b/data/109/169/155/5/1091691555.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.331792,
-    "geom:area_square_m":3027033444.920885,
+    "geom:area_square_m":3027033772.261992,
     "geom:bbox":"73.605707,41.842761,74.38111,43.223861",
     "geom:latitude":42.452737,
     "geom:longitude":73.950779,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"KG.CU.JA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879379,
-    "wof:geomhash":"38138f74365f3432a0d677273b599d37",
+    "wof:geomhash":"24909599618eee95d0f61f592963abc6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1091691555,
-    "wof:lastmodified":1627522279,
+    "wof:lastmodified":1695886747,
     "wof:name":"Jaiyl",
     "wof:parent_id":85672981,
     "wof:placetype":"county",

--- a/data/109/169/157/9/1091691579.geojson
+++ b/data/109/169/157/9/1091691579.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.168825,
-    "geom:area_square_m":1532602295.552488,
+    "geom:area_square_m":1532602295.553187,
     "geom:bbox":"73.906856695,42.360326118,74.250446217,43.193912108",
     "geom:latitude":42.76296,
     "geom:longitude":74.078565,
@@ -798,9 +798,10 @@
     "wof:concordances":{
         "hasc:id":"KG.CU.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879381,
-    "wof:geomhash":"6b03c2973f4ac9bce378d56a69158693",
+    "wof:geomhash":"1b49484c08abc49af8c8fb0a9a4929fb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -810,7 +811,7 @@
         }
     ],
     "wof:id":1091691579,
-    "wof:lastmodified":1566727154,
+    "wof:lastmodified":1695886185,
     "wof:name":"Moscow",
     "wof:parent_id":85672981,
     "wof:placetype":"county",

--- a/data/109/169/161/3/1091691613.geojson
+++ b/data/109/169/161/3/1091691613.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.222675,
-    "geom:area_square_m":2019129070.085466,
+    "geom:area_square_m":2019128823.943172,
     "geom:bbox":"74.109732,42.430203,74.560379,43.26612",
     "geom:latitude":42.834379,
     "geom:longitude":74.323937,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"KG.CU.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879383,
-    "wof:geomhash":"394aaa46d89f9649ad088cb21933d8a6",
+    "wof:geomhash":"fac15917903af59696f1310839a895da",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091691613,
-    "wof:lastmodified":1627522281,
+    "wof:lastmodified":1695886749,
     "wof:name":"Sokuluk",
     "wof:parent_id":85672981,
     "wof:placetype":"county",

--- a/data/109/169/165/5/1091691655.geojson
+++ b/data/109/169/165/5/1091691655.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.15625,
-    "geom:area_square_m":1419132986.792494,
+    "geom:area_square_m":1419133142.4014,
     "geom:bbox":"74.393185,42.400967,74.765312,43.158396",
     "geom:latitude":42.733218,
     "geom:longitude":74.593763,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"KG.CU.AM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879384,
-    "wof:geomhash":"64970fc4d86b544ba5b378d519296a67",
+    "wof:geomhash":"fc03b14e17aa8a94a00f61d6384d7678",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1091691655,
-    "wof:lastmodified":1627522278,
+    "wof:lastmodified":1695886747,
     "wof:name":"Alamudun",
     "wof:parent_id":85672981,
     "wof:placetype":"county",

--- a/data/109/169/168/9/1091691689.geojson
+++ b/data/109/169/168/9/1091691689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.208258,
-    "geom:area_square_m":1892192523.690006,
+    "geom:area_square_m":1892192251.455814,
     "geom:bbox":"74.686782,42.418442,75.182734,43.002449",
     "geom:latitude":42.710515,
     "geom:longitude":74.916715,
@@ -135,9 +135,10 @@
         "hasc:id":"KG.CU.YA",
         "wd:id":"Q878625"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879386,
-    "wof:geomhash":"296d99913de5dbbee572f261431be455",
+    "wof:geomhash":"23ea2f114a326635611cadef08700f0e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1091691689,
-    "wof:lastmodified":1690938086,
+    "wof:lastmodified":1695886184,
     "wof:name":"Ysyk-Ata",
     "wof:parent_id":85672981,
     "wof:placetype":"county",

--- a/data/109/169/173/1/1091691731.geojson
+++ b/data/109/169/173/1/1091691731.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.177744,
-    "geom:area_square_m":1617654771.891735,
+    "geom:area_square_m":1617655086.779293,
     "geom:bbox":"75.032068,42.417377,75.695214,42.879966",
     "geom:latitude":42.606171,
     "geom:longitude":75.336415,
@@ -62,9 +62,10 @@
     "wof:concordances":{
         "hasc:id":"KG.CU.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879387,
-    "wof:geomhash":"bad18fb88e2a18ecd54d6ca59a854840",
+    "wof:geomhash":"7d6eab211a926462d3a288e4f3ab3627",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1091691731,
-    "wof:lastmodified":1627522279,
+    "wof:lastmodified":1695886748,
     "wof:name":"Chui",
     "wof:parent_id":85672981,
     "wof:placetype":"county",

--- a/data/109/169/177/5/1091691775.geojson
+++ b/data/109/169/177/5/1091691775.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.37539,
-    "geom:area_square_m":3406762780.149791,
+    "geom:area_square_m":3406762780.149892,
     "geom:bbox":"75.443196694,42.44640989,77.225167527,42.987719662",
     "geom:latitude":42.782548,
     "geom:longitude":76.193107,
@@ -119,9 +119,10 @@
     "wof:concordances":{
         "hasc:id":"KG.CU.KE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879389,
-    "wof:geomhash":"d2243d0bdab09bbb5120869b2cbf3b81",
+    "wof:geomhash":"b1311ae2176fd0f97bf84d945456d527",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1091691775,
-    "wof:lastmodified":1566727158,
+    "wof:lastmodified":1695886186,
     "wof:name":"Kemin",
     "wof:parent_id":85672981,
     "wof:placetype":"county",

--- a/data/109/169/181/3/1091691813.geojson
+++ b/data/109/169/181/3/1091691813.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.983033,
-    "geom:area_square_m":18532241992.337433,
+    "geom:area_square_m":18532241777.912533,
     "geom:bbox":"74.158498,40.280971,77.907331,41.433477",
     "geom:latitude":40.905478,
     "geom:longitude":76.001503,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"KG.NA.AH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879391,
-    "wof:geomhash":"3f531ca702077abf807b51ce0b1ab599",
+    "wof:geomhash":"6b7821ceb75c44dc61da50f60bc6f139",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1091691813,
-    "wof:lastmodified":1627522279,
+    "wof:lastmodified":1695886748,
     "wof:name":"Ak-Bashy",
     "wof:parent_id":85672987,
     "wof:placetype":"county",

--- a/data/109/169/185/3/1091691853.geojson
+++ b/data/109/169/185/3/1091691853.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005225,
-    "geom:area_square_m":47632691.629329,
+    "geom:area_square_m":47632710.905654,
     "geom:bbox":"78.273541,42.43679,78.485051,42.587464",
     "geom:latitude":42.500703,
     "geom:longitude":78.386395,
@@ -126,9 +126,10 @@
         "hasc:id":"KG.YK.AS",
         "wd:id":"Q755002"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879393,
-    "wof:geomhash":"87a97641baa0c8933df09bc25390534d",
+    "wof:geomhash":"47e603cfcdf31074baaca407ba069d54",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1091691853,
-    "wof:lastmodified":1690938087,
+    "wof:lastmodified":1695886186,
     "wof:name":"Karakol",
     "wof:parent_id":85672983,
     "wof:placetype":"county",

--- a/data/109/169/190/3/1091691903.geojson
+++ b/data/109/169/190/3/1091691903.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00272,
-    "geom:area_square_m":24814109.737822,
+    "geom:area_square_m":24814105.537504,
     "geom:bbox":"76.130599,42.426462,76.244639,42.483287",
     "geom:latitude":42.460825,
     "geom:longitude":76.187448,
@@ -167,9 +167,10 @@
     "wof:concordances":{
         "hasc:id":"KG.YK.YK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879395,
-    "wof:geomhash":"c76f1da04da80397237e5e15994cc5eb",
+    "wof:geomhash":"d4eef7e360f980f418bd41e08256b7d0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":1091691903,
-    "wof:lastmodified":1636500643,
+    "wof:lastmodified":1695886763,
     "wof:name":"Balykchy",
     "wof:parent_id":85672983,
     "wof:placetype":"county",

--- a/data/109/169/193/1/1091691931.geojson
+++ b/data/109/169/193/1/1091691931.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0031,
-    "geom:area_square_m":28919898.547882,
+    "geom:area_square_m":28920098.654043,
     "geom:bbox":"73.146514,40.974922,73.23886,41.049779",
     "geom:latitude":41.018978,
     "geom:longitude":73.197987,
@@ -61,9 +61,10 @@
     "wof:concordances":{
         "hasc:id":"KG.DA.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879396,
-    "wof:geomhash":"f14d796929a8e583e607676de00abb73",
+    "wof:geomhash":"dedae01e566b21e2407a714d8096dd3a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -73,7 +74,7 @@
         }
     ],
     "wof:id":1091691931,
-    "wof:lastmodified":1627522280,
+    "wof:lastmodified":1695886748,
     "wof:name":"Kok-Zhangak",
     "wof:parent_id":85672997,
     "wof:placetype":"county",

--- a/data/109/169/197/5/1091691975.geojson
+++ b/data/109/169/197/5/1091691975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002009,
-    "geom:area_square_m":18642061.968314,
+    "geom:area_square_m":18642095.40086,
     "geom:bbox":"72.181826,41.328086,72.239789,41.418731",
     "geom:latitude":41.37084,
     "geom:longitude":72.215928,
@@ -62,9 +62,10 @@
     "wof:concordances":{
         "hasc:id":"KG.DA.AK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879398,
-    "wof:geomhash":"8624b68b1275b757b7ae6663bdd5e89a",
+    "wof:geomhash":"0df1b660e6d852f274ff66257a9fa47e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1091691975,
-    "wof:lastmodified":1627522281,
+    "wof:lastmodified":1695886749,
     "wof:name":"Tash-Kumir",
     "wof:parent_id":85672997,
     "wof:placetype":"county",

--- a/data/109/169/202/1/1091692021.geojson
+++ b/data/109/169/202/1/1091692021.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002313,
-    "geom:area_square_m":21607167.779189,
+    "geom:area_square_m":21607147.503715,
     "geom:bbox":"72.957188,40.904927,73.03582,40.960748",
     "geom:latitude":40.933646,
     "geom:longitude":73.002451,
@@ -217,9 +217,10 @@
     "wof:concordances":{
         "hasc:id":"KG.DA.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879400,
-    "wof:geomhash":"5d1e9e5b0ff94cec8ef6c679d15e3ae3",
+    "wof:geomhash":"d274ea0c93608ac867befe58cb772a8d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -229,7 +230,7 @@
         }
     ],
     "wof:id":1091692021,
-    "wof:lastmodified":1636500643,
+    "wof:lastmodified":1695886763,
     "wof:name":"Jalal-Abad",
     "wof:parent_id":85672997,
     "wof:placetype":"county",

--- a/data/109/169/205/1/1091692051.geojson
+++ b/data/109/169/205/1/1091692051.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013701,
-    "geom:area_square_m":127309217.995806,
+    "geom:area_square_m":127309137.562505,
     "geom:bbox":"72.363114,41.177526,72.573711,41.339067",
     "geom:latitude":41.281504,
     "geom:longitude":72.461102,
@@ -123,9 +123,10 @@
         "hasc:id":"KG.DA.NN",
         "wd:id":"Q2573293"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879401,
-    "wof:geomhash":"5df4fb104d1d3b8bed255c15015b023d",
+    "wof:geomhash":"657b197df6ccd270fa2c5bd2b2104676",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1091692051,
-    "wof:lastmodified":1627522280,
+    "wof:lastmodified":1695886748,
     "wof:name":"Mailuu-Suu",
     "wof:parent_id":85672997,
     "wof:placetype":"county",

--- a/data/109/169/208/7/1091692087.geojson
+++ b/data/109/169/208/7/1091692087.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004415,
-    "geom:area_square_m":40938647.275273,
+    "geom:area_square_m":40938582.109644,
     "geom:bbox":"75.929346,41.396682,76.09385,41.438212",
     "geom:latitude":41.418029,
     "geom:longitude":76.006714,
@@ -190,9 +190,10 @@
     "wof:concordances":{
         "hasc:id":"KG.NA.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879403,
-    "wof:geomhash":"a133909ac4ca73ec0458c8fd7ef796d5",
+    "wof:geomhash":"eb92de43271708c2f508db7ef2868008",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -202,7 +203,7 @@
         }
     ],
     "wof:id":1091692087,
-    "wof:lastmodified":1636500644,
+    "wof:lastmodified":1695886763,
     "wof:name":"Naryn",
     "wof:parent_id":85672987,
     "wof:placetype":"county",

--- a/data/109/169/213/1/1091692131.geojson
+++ b/data/109/169/213/1/1091692131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001589,
-    "geom:area_square_m":15061889.632311,
+    "geom:area_square_m":15061847.189524,
     "geom:bbox":"69.562753,39.907126,69.616149,39.964164",
     "geom:latitude":39.936671,
     "geom:longitude":69.585555,
@@ -104,9 +104,10 @@
     "wof:concordances":{
         "hasc:id":"KG.BA.LA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879404,
-    "wof:geomhash":"0c8f5490dbf986ed10de5a4292833c9e",
+    "wof:geomhash":"222fa67fce5701c6c3dccc77960839ac",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1091692131,
-    "wof:lastmodified":1627522281,
+    "wof:lastmodified":1695886749,
     "wof:name":"Sulukta",
     "wof:parent_id":85672995,
     "wof:placetype":"county",

--- a/data/109/169/217/3/1091692173.geojson
+++ b/data/109/169/217/3/1091692173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002166,
-    "geom:area_square_m":20440040.029754,
+    "geom:area_square_m":20440148.950362,
     "geom:bbox":"72.096841,40.218259,72.171691,40.276116",
     "geom:latitude":40.246398,
     "geom:longitude":72.134999,
@@ -62,9 +62,10 @@
     "wof:concordances":{
         "hasc:id":"KG.BA.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879406,
-    "wof:geomhash":"486dea168e1e20d503aab55dd90f0e1f",
+    "wof:geomhash":"4ebdc8d7bb6e9fb558b48d11a7f3d559",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1091692173,
-    "wof:lastmodified":1627522280,
+    "wof:lastmodified":1695886749,
     "wof:name":"Kyzyl-Kia",
     "wof:parent_id":85672995,
     "wof:placetype":"county",

--- a/data/109/169/221/3/1091692213.geojson
+++ b/data/109/169/221/3/1091692213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001466,
-    "geom:area_square_m":13355571.878117,
+    "geom:area_square_m":13355580.304484,
     "geom:bbox":"72.186038,42.505996,72.280355,42.542994",
     "geom:latitude":42.523487,
     "geom:longitude":72.238785,
@@ -124,9 +124,10 @@
     "wof:concordances":{
         "hasc:id":"KG.TL.TC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879407,
-    "wof:geomhash":"34f476a9f92e5c5f07b6bff1364fbb6f",
+    "wof:geomhash":"a312afa4d3f750567ceb7a1fc9594244",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1091692213,
-    "wof:lastmodified":1636500642,
+    "wof:lastmodified":1695886762,
     "wof:name":"Talas",
     "wof:parent_id":85673003,
     "wof:placetype":"county",

--- a/data/109/169/225/5/1091692255.geojson
+++ b/data/109/169/225/5/1091692255.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003974,
-    "geom:area_square_m":36036062.927403,
+    "geom:area_square_m":36036062.927406,
     "geom:bbox":"75.23012678,42.782559203,75.358102926,42.861539884",
     "geom:latitude":42.83354,
     "geom:longitude":75.296977,
@@ -170,9 +170,10 @@
     "wof:concordances":{
         "hasc:id":"KG.CU.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KG",
     "wof:created":1473879409,
-    "wof:geomhash":"576373bd40540002ea158d2b1152c25a",
+    "wof:geomhash":"d56a3a79f0dcc1b814951e6cf2cdc0cc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -182,7 +183,7 @@
         }
     ],
     "wof:id":1091692255,
-    "wof:lastmodified":1566727157,
+    "wof:lastmodified":1695886186,
     "wof:name":"Tokmok",
     "wof:parent_id":85672981,
     "wof:placetype":"county",

--- a/data/110/880/489/1/1108804891.geojson
+++ b/data/110/880/489/1/1108804891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003291,
-    "geom:area_square_m":30929380.731963,
+    "geom:area_square_m":30929466.413327,
     "geom:bbox":"72.762238,40.471576,72.83418,40.589054",
     "geom:latitude":40.521386,
     "geom:longitude":72.802107,
@@ -64,11 +64,13 @@
     "wof:concordances":{
         "fips:code":"KG10",
         "hasc:id":"KG.OC",
+        "iso:code":"KG-GO",
         "iso:id":"KG-GO"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KG",
     "wof:created":1485453182,
-    "wof:geomhash":"ccc3f56d73cf69205510b24f3d439ef6",
+    "wof:geomhash":"7d5f28b1e4799b9cc603f4cc04612b9c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -85,7 +87,7 @@
         "kir",
         "rus"
     ],
-    "wof:lastmodified":1627522281,
+    "wof:lastmodified":1695884754,
     "wof:name":"Osh City",
     "wof:parent_id":85632761,
     "wof:placetype":"region",

--- a/data/856/327/61/85632761.geojson
+++ b/data/856/327/61/85632761.geojson
@@ -1319,6 +1319,7 @@
         "hasc:id":"KG",
         "icao:code":"EX",
         "ioc:id":"KGZ",
+        "iso:code":"KG",
         "itu:id":"KGZ",
         "loc:id":"n91129681",
         "m49:code":"417",
@@ -1333,6 +1334,7 @@
         "wk:page":"Kyrgyzstan",
         "wmo:id":"KG"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KG",
     "wof:country_alpha3":"KGZ",
     "wof:geom_alt":[
@@ -1356,7 +1358,7 @@
         "kir",
         "rus"
     ],
-    "wof:lastmodified":1694639528,
+    "wof:lastmodified":1695881184,
     "wof:name":"Kyrgyzstan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/729/75/85672975.geojson
+++ b/data/856/729/75/85672975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016552,
-    "geom:area_square_m":150000343.965059,
+    "geom:area_square_m":150000511.999823,
     "geom:bbox":"74.499765,42.751884,74.701076,42.987011",
     "geom:latitude":42.869898,
     "geom:longitude":74.594647,
@@ -656,6 +656,7 @@
         "gn:id":1528334,
         "gp:id":20070194,
         "hasc:id":"KG.GB",
+        "iso:code":"KG-GB",
         "iso:id":"KG-GB",
         "loc:id":"n91129719",
         "qs_pg:id":1287644,
@@ -663,6 +664,7 @@
         "wd:id":"Q9361",
         "wk:page":"Bishkek"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421168899
     ],
@@ -670,7 +672,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"556a2fcb039d6154acd6a0c05f511c81",
+    "wof:geomhash":"e22a7e06f86f430d8ca34ad66dbd8623",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -687,7 +689,7 @@
         "kir",
         "rus"
     ],
-    "wof:lastmodified":1690938083,
+    "wof:lastmodified":1695884363,
     "wof:name":"Bishkek",
     "wof:parent_id":85632761,
     "wof:placetype":"region",

--- a/data/856/729/81/85672981.geojson
+++ b/data/856/729/81/85672981.geojson
@@ -346,10 +346,12 @@
         "gn:id":1538652,
         "gp:id":20070195,
         "hasc:id":"KG.CU",
+        "iso:code":"KG-C",
         "qs_pg:id":1287645,
         "wd:id":"Q486370",
         "wk:page":"Chuy Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KG",
     "wof:geom_alt":[
         "quattroshapes"
@@ -371,7 +373,7 @@
         "kir",
         "rus"
     ],
-    "wof:lastmodified":1694493258,
+    "wof:lastmodified":1695884872,
     "wof:name":"Chuy",
     "wof:parent_id":85632761,
     "wof:placetype":"region",

--- a/data/856/729/83/85672983.geojson
+++ b/data/856/729/83/85672983.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.927516,
-    "geom:area_square_m":36018481522.664085,
+    "geom:area_square_m":36018481076.486259,
     "geom:bbox":"75.641311,41.181538,80.226452,42.941789",
     "geom:latitude":42.125218,
     "geom:longitude":78.044363,
@@ -359,17 +359,19 @@
         "gn:id":1528260,
         "gp:id":20070190,
         "hasc:id":"KG.YK",
+        "iso:code":"KG-Y",
         "iso:id":"KG-Y",
         "qs_pg:id":236957,
         "unlc:id":"KG-Y",
         "wd:id":"Q487413",
         "wk:page":"Issyk-Kul Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"942ae31a15ba3776f4e2971ad96bfc40",
+    "wof:geomhash":"8d33b411dcfa79015c35c60fa79767cb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -386,7 +388,7 @@
         "kir",
         "rus"
     ],
-    "wof:lastmodified":1690938084,
+    "wof:lastmodified":1695884519,
     "wof:name":"Ysyk-K\u00f6l",
     "wof:parent_id":85632761,
     "wof:placetype":"region",

--- a/data/856/729/87/85672987.geojson
+++ b/data/856/729/87/85672987.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.807331,
-    "geom:area_square_m":44611388636.259109,
+    "geom:area_square_m":44611386946.423798,
     "geom:bbox":"73.712814,40.280971,77.907331,42.453003",
     "geom:latitude":41.365217,
     "geom:longitude":75.605078,
@@ -368,17 +368,19 @@
         "gn:id":1527590,
         "gp:id":20070191,
         "hasc:id":"KG.NA",
+        "iso:code":"KG-N",
         "iso:id":"KG-N",
         "qs_pg:id":1287643,
         "unlc:id":"KG-N",
         "wd:id":"Q486375",
         "wk:page":"Naryn Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7f08f0797e7257b09d1d1ba4e3da53cd",
+    "wof:geomhash":"26c9efa065c966311e411524b1b8350e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -395,7 +397,7 @@
         "kir",
         "rus"
     ],
-    "wof:lastmodified":1690938083,
+    "wof:lastmodified":1695884872,
     "wof:name":"Naryn",
     "wof:parent_id":85632761,
     "wof:placetype":"region",

--- a/data/856/729/95/85672995.geojson
+++ b/data/856/729/95/85672995.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.785647,
-    "geom:area_square_m":16944098800.403152,
+    "geom:area_square_m":16944098843.435209,
     "geom:bbox":"69.26385,39.388948,72.544867,40.347447",
     "geom:latitude":39.878624,
     "geom:longitude":70.868104,
@@ -351,17 +351,19 @@
         "gn:id":1463580,
         "gp:id":20070196,
         "hasc:id":"KG.BA",
+        "iso:code":"KG-B",
         "iso:id":"KG-B",
         "qs_pg:id":1287646,
         "unlc:id":"KG-B",
         "wd:id":"Q487631",
         "wk:page":"Batken Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e042f54afe6fdb70da90f10e95cddca8",
+    "wof:geomhash":"5bde6a8ab29dee0a9543a5e966bd7664",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -378,7 +380,7 @@
         "kir",
         "rus"
     ],
-    "wof:lastmodified":1690938082,
+    "wof:lastmodified":1695884872,
     "wof:name":"Batken",
     "wof:parent_id":85632761,
     "wof:placetype":"region",

--- a/data/856/729/97/85672997.geojson
+++ b/data/856/729/97/85672997.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.629685,
-    "geom:area_square_m":33577660462.533951,
+    "geom:area_square_m":33577660591.174187,
     "geom:bbox":"70.169149,40.8042,74.74013,42.221187",
     "geom:latitude":41.569902,
     "geom:longitude":72.455582,
@@ -332,17 +332,19 @@
         "gn:id":1529778,
         "gp:id":20070193,
         "hasc:id":"KG.CU",
+        "iso:code":"KG-C",
         "iso:id":"KG-C",
         "qs_pg:id":896384,
         "unlc:id":"KG-J",
         "wd:id":"Q487640",
         "wk:page":"Jalal-Abad Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b862bccc65e72dbd6cbbd6c5c4230d3d",
+    "wof:geomhash":"b1ca83d0d92173eeecfe7b992bb25d9a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -359,7 +361,7 @@
         "kir",
         "rus"
     ],
-    "wof:lastmodified":1690938084,
+    "wof:lastmodified":1695884872,
     "wof:name":"Jalal-Abad",
     "wof:parent_id":85632761,
     "wof:placetype":"region",

--- a/data/856/730/03/85673003.geojson
+++ b/data/856/730/03/85673003.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.253841,
-    "geom:area_square_m":11442596173.406702,
+    "geom:area_square_m":11442596773.955025,
     "geom:bbox":"70.864634,42.049063,73.658246,42.840584",
     "geom:latitude":42.434819,
     "geom:longitude":72.126937,
@@ -356,17 +356,19 @@
         "gn:id":1527297,
         "gp:id":20070192,
         "hasc:id":"KG.TL",
+        "iso:code":"KG-T",
         "iso:id":"KG-T",
         "qs_pg:id":236958,
         "unlc:id":"KG-T",
         "wd:id":"Q109838",
         "wk:page":"Talas Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1bee4a2bfeb186f3899dc62969a4c27e",
+    "wof:geomhash":"bde4f644b05a8fa0540789ce1e6a46a1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -383,7 +385,7 @@
         "kir",
         "rus"
     ],
-    "wof:lastmodified":1690938080,
+    "wof:lastmodified":1695884872,
     "wof:name":"Talas",
     "wof:parent_id":85632761,
     "wof:placetype":"region",

--- a/data/856/730/05/85673005.geojson
+++ b/data/856/730/05/85673005.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.078061,
-    "geom:area_square_m":29097548765.832699,
+    "geom:area_square_m":29097548136.384033,
     "geom:bbox":"71.498706,39.180427,74.911163,41.146402",
     "geom:latitude":40.135256,
     "geom:longitude":73.224575,
@@ -382,17 +382,19 @@
         "gn:id":1346798,
         "gp:id":20070197,
         "hasc:id":"KG.OH",
+        "iso:code":"KG-O",
         "iso:id":"KG-O",
         "qs_pg:id":1287655,
         "unlc:id":"KG-O",
         "wd:id":"Q231987",
         "wk:page":"Osh Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9a3880c478c1b4dcebac85be5b906a4b",
+    "wof:geomhash":"1267c7a2555633a53b91cbe1c8ffcb2a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -409,7 +411,7 @@
         "kir",
         "rus"
     ],
-    "wof:lastmodified":1690938080,
+    "wof:lastmodified":1695884362,
     "wof:name":"Osh",
     "wof:parent_id":85632761,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.